### PR TITLE
Add tracer user for kerberized accumulo

### DIFF
--- a/onefs/isilon_create_users.sh
+++ b/onefs/isilon_create_users.sh
@@ -159,7 +159,7 @@ case "$DIST" in
         # See http://docs.hortonworks.com/HDPDocuments/Ambari-2.1.1.0/bk_ambari_reference_guide/content/_defining_service_users_and_groups_for_a_hdp_2x_stack.html
         SUPER_USERS="hdfs mapred yarn hbase storm falcon"
         SUPER_GROUPS="hadoop"
-        REQUIRED_USERS="$SUPER_USERS tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop anonymous spark mahout ranger kms atlas ams"
+        REQUIRED_USERS="$SUPER_USERS tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop anonymous spark mahout ranger kms atlas ams tracer"
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         ;;
     "phd")


### PR DESCRIPTION
When the cluster is kerberized, accumulo requires the tracer user to have read access to apps/accumulo/data/instance_id to read the id value. This addresses half of the problem: the creation of the user. Does not apply to non-secure.
