### PR TITLE
Ability to append cluster name to all service accounts and remove isi_run depdency

### DIFF
--- a/onefs/isilon_create_directories.sh
+++ b/onefs/isilon_create_directories.sh
@@ -16,6 +16,7 @@ declare -a ERRORLIST=()
 DIST=""
 FIXPERM="n"
 ZONE="System"
+CLUSTERNAME=""
 
 #set -x
 
@@ -93,7 +94,7 @@ function getAccessZoneId() {
 #Params: Username
 function getUserUid() {
     local uid
-    uid=$(isi auth users view --zone $ZONE $1 | grep "  UID" | cut -f2 -d :)
+    uid=$(isi auth users view --zone $ZONE $1$CLUSTERNAME | grep "  UID" | cut -f2 -d :)
     echo $uid
 }
 
@@ -131,6 +132,11 @@ while [ "z$1" != "z" ] ; do
       "--fixperm")
              echo "Info: will fix permissions and owners on existing directories"
              FIXPERM="y"
+             ;;
+      "--append-cluster-name"
+             shift
+             CLUSTERNAME="-$1"
+             echo "Info: will add clustername to end of usernames: $CLUSTERNAME"
              ;;
       *)     echo "ERROR -- unknown arg $1"
              usage

--- a/onefs/isilon_create_directories.sh
+++ b/onefs/isilon_create_directories.sh
@@ -27,7 +27,7 @@ function banner() {
 }
 
 function usage() {
-   echo "$0 --dist <cdh|hwx|phd|phd3|bi> [--zone <ZONE>] [--fixperm]"
+   echo "$0 --dist <cdh|hwx|phd|phd3|bi> [--zone <ZONE>] [--fixperm] [--append-cluster-name <clustername>]"
    exit 1
 }
 
@@ -133,7 +133,7 @@ while [ "z$1" != "z" ] ; do
              echo "Info: will fix permissions and owners on existing directories"
              FIXPERM="y"
              ;;
-      "--append-cluster-name"
+      "--append-cluster-name")
              shift
              CLUSTERNAME="-$1"
              echo "Info: will add clustername to end of usernames: $CLUSTERNAME"

--- a/onefs/isilon_create_directories.sh
+++ b/onefs/isilon_create_directories.sh
@@ -54,7 +54,7 @@ function makedir() {
    if [ "z$1" == "z" ] ; then
       echo "ERROR -- function makedir needs directory as an argument"
    else
-      mkdir $1
+      mkdir -p $1
    fi
 }
 

--- a/onefs/isilon_create_directories.sh
+++ b/onefs/isilon_create_directories.sh
@@ -101,7 +101,7 @@ function getUserUid() {
 #Params: GroupName
 function getGroupGid() {
     local gid
-    gid=$(isi auth groups view --zone $ZONE $1 | grep "  GID:" | cut -f2 -d :)
+    gid=$(isi auth groups view --zone $ZONE $1$CLUSTERNAME | grep "  GID:" | cut -f2 -d :)
     echo $gid
 }
 

--- a/onefs/isilon_create_directories.sh
+++ b/onefs/isilon_create_directories.sh
@@ -61,9 +61,15 @@ function fixperm() {
    if [ "z$1" == "z" ] ; then
       echo "ERROR -- function fixperm needs directory owner group perm as an argument"
    else
-      isi_run -z $ZONEID chown $2 $1
-      isi_run -z $ZONEID chown :$3 $1
-      isi_run -z $ZONEID chmod $4 $1
+      uid=$(getUserUid $2)
+      gid=$(getGroupGid $3)
+      chown $uid $1
+      chown :$gid $1
+      chmod $4 $1
+
+      #isi_run -z $ZONEIDchown $2 $1
+      #isi_run -z $ZONEID chown :$3 $1
+      #isi_run -z $ZONEID chmod $4 $1
    fi
 }
 
@@ -80,9 +86,24 @@ function getHdfsRoot() {
 
 function getAccessZoneId() {
     local zoneid
-    hdfsroot=$(isi zone zones view $1 | grep "Zone ID:" | cut -f2 -d :)
-    echo $hdfsroot
+    zoneid=$(isi zone zones view $1 | grep "Zone ID:" | cut -f2 -d :)
+    echo $zoneid
 }
+
+#Params: Username
+function getUserUid() {
+    local uid
+    uid=$(isi auth users view --zone $ZONE $1 | grep "  UID" | cut -f2 -d :)
+    echo $uid
+}
+
+#Params: GroupName
+function getGroupGid() {
+    local gid
+    gid=$(isi auth groups view --zone $ZONE $1 | grep "  GID:" | cut -f2 -d :)
+    echo $gid
+}
+
 
 if [ "`uname`" != "Isilon OneFS" ]; then
    fatal "Script must be run on Isilon cluster as root."

--- a/onefs/isilon_create_users.sh
+++ b/onefs/isilon_create_users.sh
@@ -223,7 +223,7 @@ for user in $REQUIRED_USERS; do
        user=$(getUserFromUid $uid $ZONE)
        addError "UID $uid already in use by user $user$CLUSTERNAME in zone $ZONE"
     else
-       isi auth users create $user$CLUSTERNAME --uid $uid --primary-group $user$CLUSTERNAME --zone $ZONE --provider local --home-directory $HDFSROOT/user/$user
+       isi auth users create $user$CLUSTERNAME --uid $uid --primary-group $user$CLUSTERNAME --zone $ZONE --provider local --home-directory $HDFSROOT/user/$user$CLUSTERNAME
        [ $? -ne 0 ] && addError "Could not create user $user$CLUSTERNAME with uid $uid in zone $ZONE"
     fi
     uid=$(( $uid + 1 ))

--- a/onefs/isilon_create_users.sh
+++ b/onefs/isilon_create_users.sh
@@ -206,8 +206,8 @@ for group in $REQUIRED_GROUPS; do
        group=$(getGroupFromGid $gid $ZONE)
        addError "GID $gid already in use by group $group in zone $ZONE"
     else
-       isi auth groups create $group --gid $gid --zone $ZONE
-       [ $? -ne 0 ] && addError "Could not create group $group with gid $gid in zone $ZONE"
+       isi auth groups create $group$CLUSTERNAME --gid $gid --zone $ZONE
+       [ $? -ne 0 ] && addError "Could not create group $group$CLUSTERNAME with gid $gid in zone $ZONE"
     fi
     gid=$(( $gid + 1 ))
 done
@@ -218,36 +218,36 @@ for user in $REQUIRED_USERS; do
     # echo "DEBUG:  UID=$uid"
     if userExists $user $ZONE ; then
        uid=$(getUidFromUser $user $ZONE)
-       addError "User $user already exists at uid $uid in zone $ZONE"
+       addError "User $user$CLUSTERNAME already exists at uid $uid in zone $ZONE"
     elif uidInUse $uid $ZONE ; then
        user=$(getUserFromUid $uid $ZONE)
-       addError "UID $uid already in use by user $user in zone $ZONE"
+       addError "UID $uid already in use by user $user$CLUSTERNAME in zone $ZONE"
     else
-       isi auth users create $user$CLUSTERNAME --uid $uid --primary-group $user --zone $ZONE --provider local --home-directory $HDFSROOT/user/$user
-       [ $? -ne 0 ] && addError "Could not create user $user with uid $uid in zone $ZONE"
+       isi auth users create $user$CLUSTERNAME --uid $uid --primary-group $user$CLUSTERNAME --zone $ZONE --provider local --home-directory $HDFSROOT/user/$user
+       [ $? -ne 0 ] && addError "Could not create user $user$CLUSTERNAME with uid $uid in zone $ZONE"
     fi
     uid=$(( $uid + 1 ))
 done
 
 for user in $SUPER_USERS; do
     for group in $SUPER_GROUPS; do
-       isi auth groups modify $group --add-user $user$CLUSTERNAME --zone $ZONE
-       [ $? -ne 0 ] && addError "Could not add user $user$CLUSTERNAME to $group group in zone $ZONE"
+       isi auth groups modify $group$CLUSTERNAME --add-user $user$CLUSTERNAME --zone $ZONE
+       [ $? -ne 0 ] && addError "Could not add user $user$CLUSTERNAME to $group$CLUSTERNAME group in zone $ZONE"
        done
 done
 
 # Special cases
 case "$DIST" in
     "cdh")
-        isi auth groups modify sqoop --add-user sqoop2$CLUSTERNAME --zone $ZONE
+        isi auth groups modify sqoop$CLUSTERNAME --add-user sqoop2$CLUSTERNAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user sqoop2 to sqoop group in zone $ZONE"
         ;;
     "bi")
-        isi auth groups modify users$ --add-user hive$CLUSTERNAME --zone $ZONE
+        isi auth groups modify users$CLUSTERNAME --add-user hive$CLUSTERNAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user hive to users group in zone $ZONE"
-        isi auth groups modify hcat --add-user hive$CLUSTERNAME --zone $ZONE
+        isi auth groups modify hcat$CLUSTERNAME --add-user hive$CLUSTERNAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user hive to hcat group in zone $ZONE"
-        isi auth groups modify knox --add-user kafka$CLUSTERNAME --zone $ZONE
+        isi auth groups modify knox$CLUSTERNAME --add-user kafka$CLUSTERNAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user kafka to knox group in zone $ZONE"
         ;;
 esac

--- a/onefs/isilon_create_users.sh
+++ b/onefs/isilon_create_users.sh
@@ -141,7 +141,7 @@ while [ "z$1" != "z" ] ; do
              ZONE="$1"
              echo "Info: will put users in zone:  $ZONE"
              ;;
-      "--append-cluster-name"
+      "--append-cluster-name")
              shift
              CLUSTERNAME="-$1"
              echo "Info: will add clustername to end of usernames: $CLUSTERNAME"


### PR DESCRIPTION
Append cluster name to end of service accounts to allow for multi tenancy if integrating into AD and using Kerberos. 

isi_run can take up to 20 minutes per call on busy clusters because it runs a flush command, in recent 7.2 code.  See SR# 79376824, removed, by quering the UID and GID from the zone and using directly with chown.

Mkdir added a -p to fix error with creating the /system/yarn/ folder
